### PR TITLE
Allow opting out of the listings xpromo experiment

### DIFF
--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -64,7 +64,7 @@ export const VISITED_POSTS_COUNT = 20;
 
 export const RECENT_CLICKS_LENGTH = 5;
 
-export const XPROMO_LISTING_OPT_OUT = 'no_xpromo_listing_interstitial';
+export const XPROMO_INTERSTITIAL_OPT_OUT = 'no_xpromo_interstitial';
 
 // Post content
 

--- a/src/app/reducers/optOuts.js
+++ b/src/app/reducers/optOuts.js
@@ -1,7 +1,7 @@
 import { merge } from '@r/platform';
 import * as platformActions from '@r/platform/actions';
 
-import { XPROMO_LISTING_OPT_OUT } from 'app/constants';
+import { XPROMO_INTERSTITIAL_OPT_OUT } from 'app/constants';
 
 const DEFAULT = {};
 
@@ -10,7 +10,7 @@ export default function (state=DEFAULT, action={}) {
     case platformActions.SET_PAGE: {
       const { queryParams } = action.payload;
 
-      const xpromoSetting = queryParams[XPROMO_LISTING_OPT_OUT];
+      const xpromoSetting = queryParams[XPROMO_INTERSTITIAL_OPT_OUT];
 
       // If the setting is not present, we treat it as such.
       if (xpromoSetting === undefined) {
@@ -20,12 +20,12 @@ export default function (state=DEFAULT, action={}) {
       // Unset the flag
       if (xpromoSetting === 'false') {
         return merge(state, {
-          xpromoListing: undefined,
+          xpromoInterstitial: undefined,
         });
       }
 
       return merge(state, {
-        xpromoListing: true,
+        xpromoInterstitial: true,
       });
     }
 


### PR DESCRIPTION
We support query parameters for setting opt-out flags, which we include
in the state and persist via localStorage. We also let the feature flag
module condition on these opt-out flags, so we can use them to determine
experiment eligibility.